### PR TITLE
Fix max6675.py

### DIFF
--- a/MAX6675/max6675.py
+++ b/MAX6675/max6675.py
@@ -1,7 +1,7 @@
 import time
 
 
-class MAX6675:
+class MAX6675():
     MEASUREMENT_PERIOD_MS = 220
 
     def __init__(self, sck, cs, so):


### PR DESCRIPTION
Added brackets after the name of the class, otherwise it can't be accessed from the module.